### PR TITLE
Example of how to map to Model CRUD

### DIFF
--- a/common/models/pet.js
+++ b/common/models/pet.js
@@ -1,5 +1,24 @@
 'use strict';
 
+const app = require('../../server/server');
 module.exports = function(Pet) {
-
+  Pet.once('attached', () => {
+    // Replace findById with your own logic
+    Pet.findById = function(id, filter) {
+      // In the case of both the result and/or the error, we only want
+      // the "obj" property since it's the closest fit to our Model,
+      // though the choice is yours to do as you will with them.
+      return getPetService().getPetById({petId: id}).then(pet => {
+        return pet.obj;
+      }).catch(err => {
+        return Promise.reject(err.obj);
+      });
+    };
+  });
 };
+
+// Use a getter function to avoid early-binding of this value,
+// since this file will be loaded before the swagger setup scripts!
+function getPetService() {
+  return app.dataSources.petstore.models.PetService;
+}

--- a/common/models/pet.json
+++ b/common/models/pet.json
@@ -1,7 +1,7 @@
 {
   "name": "Pet",
-  "base": "PersistedModel",
   "plural": "pet",
+  "base": "PersistedModel",
   "idInjection": true,
   "options": {
     "validateUpsert": true

--- a/server/boot/setup-swagger-models.js
+++ b/server/boot/setup-swagger-models.js
@@ -1,0 +1,10 @@
+'use strict';
+const loopback = require('loopback');
+module.exports = function(server) {
+  const ds = server.datasources.petstore;
+  ds.once('connected', () => {
+    // This will make a model with all of the swagger-defined endpoints
+    // for the PetService.
+    ds.createModel('PetService', {});
+  });
+};

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -39,7 +39,7 @@
     "dataSource": null
   },
   "Pet": {
-    "dataSource": "petstore",
+    "dataSource": null,
     "public": true
   }
 }


### PR DESCRIPTION
## Overview
This should cover off the general strategy for mapping between the individual endpoints as defined by the Swagger specification in your datasource and a Model class of your own making.